### PR TITLE
modify supervisor to include basic RSCP protocol functionality

### DIFF
--- a/kalman_bringup/launch/arc_pc_nav.launch.py
+++ b/kalman_bringup/launch/arc_pc_nav.launch.py
@@ -1,0 +1,29 @@
+from kalman_bringup import *
+
+RGBD_IDS = "d455_front d455_back d455_left d455_right"
+
+def generate_launch_description():
+    return gen_launch({
+        "description": {
+            "layout": "autonomy_90deg_cams",
+        },
+        "hardware": {
+            "master": "pc",
+            "rgbd_ids": RGBD_IDS,
+            "imu": "full",
+            "gps": "true",
+        },
+        "clouds": {
+            "rgbd_ids": RGBD_IDS,
+        },
+        "slam": {
+            "rgbd_ids": RGBD_IDS,
+        },
+        "nav2": {
+            "rgbd_ids": RGBD_IDS,
+        },
+        "wheels": {},
+        "supervisor": {
+            "rscp_enabled": "true",
+        },
+    })

--- a/kalman_bringup/launch/arc_sim_nav_base.launch.py
+++ b/kalman_bringup/launch/arc_sim_nav_base.launch.py
@@ -1,0 +1,15 @@
+from kalman_bringup import *
+
+
+def generate_launch_description():
+    return gen_launch({
+        "unity_sim": {
+            "scene": "ERC2023",
+            "selective_launch": "no_rs_pub",
+        },
+        "rviz": {
+            "configs": "autonomy",
+        },
+        "gs": {},
+        "wheels": {},
+    })

--- a/kalman_bringup/launch/arc_sim_nav_stack.launch.py
+++ b/kalman_bringup/launch/arc_sim_nav_stack.launch.py
@@ -1,0 +1,40 @@
+from ament_index_python import get_package_share_path
+from kalman_bringup import gen_launch
+
+RGBD_IDS = "d455_front d455_back d455_left d455_right"
+
+def generate_launch_description():
+    return gen_launch({
+        "unity_sim": {
+            "selective_launch": "only_rs_pub",
+        },
+        "description": {
+            "layout": "autonomy",
+        },
+        "clouds": {
+            "rgbd_ids": RGBD_IDS,
+        },
+        "slam": {
+            "rgbd_ids": RGBD_IDS,
+            "gps_datum": "50.8780616423677 20.642475756324",  # Marsyard S1, Kielce
+        },
+        "nav2": {
+            "rgbd_ids": RGBD_IDS,
+        },
+        # "aruco": {
+        #     "rgbd_ids": RGBD_IDS,
+        #     "dict": "4X4_50",
+        #     "size": "0.15",
+        # },
+        # "yolo": {
+        #     "rgbd_ids": RGBD_IDS,
+        #     "config": "urc2024",
+        # },
+        "supervisor": {
+            # "aruco_rgbd_ids": RGBD_IDS,
+            # "aruco_deactivate_unused": "true",
+            # "yolo_enabled": "true",
+            # "yolo_deactivate_unused": "true",
+            "rscp_enabled": "true",
+        },
+    })

--- a/kalman_interfaces/CMakeLists.txt
+++ b/kalman_interfaces/CMakeLists.txt
@@ -15,6 +15,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "action/SupervisorGpsYoloSearch.action"
   "action/SupervisorMappingGoals.action"
   "action/SupervisorTfGoal.action"
+  "msg/ArcRscpRequest.msg"
+  "msg/ArcRscpResponse.msg"
   "msg/ArmAxesLocks.msg"
   "msg/ArmCompressed.msg"
   "msg/ArmFkCommand.msg"

--- a/kalman_interfaces/msg/ArcRscpRequest.msg
+++ b/kalman_interfaces/msg/ArcRscpRequest.msg
@@ -1,0 +1,15 @@
+int32 ARM_DISARM=0
+int32 SET_STAGE=1
+int32 NAV_TO_GPS=2
+
+int32 type
+
+# ARM_DISARM
+bool arm
+
+# SET_STAGE
+uint32 stage
+
+# NAV_TO_GPS
+float64 latitude
+float64 longitude

--- a/kalman_interfaces/msg/ArcRscpResponse.msg
+++ b/kalman_interfaces/msg/ArcRscpResponse.msg
@@ -1,0 +1,4 @@
+int32 ACK=0
+int32 TASK_FINISHED=1
+
+int32 type

--- a/kalman_supervisor/kalman_supervisor/modules/__init__.py
+++ b/kalman_supervisor/kalman_supervisor/modules/__init__.py
@@ -5,6 +5,7 @@ from kalman_supervisor.modules.map import Map
 from kalman_supervisor.modules.missions import Missions
 from kalman_supervisor.modules.nav import Nav
 from kalman_supervisor.modules.position_history import PositionHistory
+from kalman_supervisor.modules.rscp import Rscp
 from kalman_supervisor.modules.tf import TF
 from kalman_supervisor.modules.ueuos import Ueuos
 from kalman_supervisor.modules.yolo import Yolo

--- a/kalman_supervisor/kalman_supervisor/modules/rscp.py
+++ b/kalman_supervisor/kalman_supervisor/modules/rscp.py
@@ -1,0 +1,127 @@
+from kalman_supervisor.module import Module
+from kalman_interfaces.msg import ArcRscpRequest, ArcRscpResponse
+
+
+class Rscp(Module):
+    def __init__(self):
+        super().__init__("rscp")
+
+    def configure(self) -> None:
+        self.supervisor.declare_parameter("rscp.enabled", False)
+
+    def activate(self) -> None:
+        self.module_enabled = self.supervisor.get_parameter("rscp.enabled").value
+        if not self.module_enabled:
+            return
+
+        self.__armed = False
+        self.__current_stage: int | None = None
+        self.__pending_request: ArcRscpRequest | None = None
+        self.__navigation_goal: tuple[float, float] | None = None  # (lat, lon)
+        
+        # Subscribe to rscp/req
+        self.__req_sub = self.supervisor.create_subscription(
+            ArcRscpRequest, 
+            "rscp/req", 
+            self.__req_callback, 
+            10
+        )
+        
+        # Publisher for rscp/res
+        self.__res_pub = self.supervisor.create_publisher(
+            ArcRscpResponse, 
+            "rscp/res", 
+            10
+        )
+
+    def __req_callback(self, msg: ArcRscpRequest) -> None:
+        # Store the request for processing
+        self.__pending_request = msg
+        self.supervisor.get_logger().info(
+            f"[RSCP] Received request type={msg.type} "
+            f"(arm={msg.arm}, stage={msg.stage}, lat={msg.latitude}, lon={msg.longitude})"
+        )
+    
+    def tick(self) -> None:
+        if not self.module_enabled:
+            return
+        
+        # Process certain request types in the module before states see them
+        if self.__pending_request is not None:
+            req = self.__pending_request
+            
+            # Handle ARM_DISARM requests immediately
+            if req.type == ArcRscpRequest.ARM_DISARM:
+                self.__armed = req.arm
+                self.send_ack()
+                self.__pending_request = None  # Consume the request
+                
+                self.supervisor.get_logger().info(
+                    f"[RSCP] ARM_DISARM: {'ARMED' if self.__armed else 'DISARMED'}"
+                )
+                
+                # Update UEUOS state based on armed status
+                if self.__armed:
+                    self.supervisor.ueuos.set_rscp_state(self.supervisor.ueuos.RscpState.ARMED)
+                else:
+                    self.supervisor.ueuos.set_rscp_state(self.supervisor.ueuos.RscpState.DISARMED)
+            
+            # Handle SET_STAGE requests immediately
+            elif req.type == ArcRscpRequest.SET_STAGE:
+                self.__current_stage = req.stage
+                self.send_ack()
+                self.__pending_request = None  # Consume the request
+                
+                self.supervisor.get_logger().info(
+                    f"[RSCP] SET_STAGE: stage={self.__current_stage}"
+                )
+            
+            # Other requests (NAV_TO_GPS) are left for states to handle
+
+    def deactivate(self) -> None:
+        if not self.module_enabled:
+            return
+        
+        self.supervisor.destroy_subscription(self.__req_sub)
+        self.supervisor.destroy_publisher(self.__res_pub)
+
+    def is_armed(self) -> bool:
+        return self.__armed
+
+    def has_pending_request(self) -> bool:
+        return self.__pending_request is not None
+
+    def pop_pending_request(self) -> ArcRscpRequest | None:
+        req = self.__pending_request
+        self.__pending_request = None
+        return req
+
+    def peek_pending_request(self) -> ArcRscpRequest | None:
+        return self.__pending_request
+
+    def send_ack(self) -> None:
+        msg = ArcRscpResponse()
+        msg.type = ArcRscpResponse.ACK
+        self.__res_pub.publish(msg)
+        self.supervisor.get_logger().info("[RSCP] Sent ACK")
+
+    def send_task_finished(self) -> None:
+        msg = ArcRscpResponse()
+        msg.type = ArcRscpResponse.TASK_FINISHED
+        self.__res_pub.publish(msg)
+        self.supervisor.get_logger().info("[RSCP] Sent TASK_FINISHED")
+
+    def get_current_stage(self) -> int | None:
+        return self.__current_stage
+    
+    def get_navigation_goal(self) -> tuple[float, float] | None:
+        return self.__navigation_goal
+    
+    def set_navigation_goal(self, lat: float, lon: float) -> None:
+        self.__navigation_goal = (lat, lon)
+        self.supervisor.get_logger().info(f"[RSCP] Navigation goal set to ({lat}, {lon})")
+    
+    def clear_navigation_goal(self) -> None:
+        self.__navigation_goal = None
+        self.supervisor.get_logger().info("[RSCP] Navigation goal cleared")
+

--- a/kalman_supervisor/kalman_supervisor/modules/ueuos.py
+++ b/kalman_supervisor/kalman_supervisor/modules/ueuos.py
@@ -2,7 +2,8 @@ from enum import IntEnum
 from rclpy import Future
 
 from kalman_supervisor.module import Module
-from kalman_interfaces.srv import SetUeuosState
+from kalman_interfaces.srv import SetUeuosState, SetUeuosColor
+from std_msgs.msg import ColorRGBA
 
 
 class Ueuos(Module):
@@ -11,12 +12,18 @@ class Ueuos(Module):
         AUTONOMY = SetUeuosState.Request.AUTONOMY
         TELEOP = SetUeuosState.Request.TELEOP
         FINISHED = SetUeuosState.Request.FINISHED
+    
+    class RscpState(IntEnum):
+        DISARMED = 0
+        ARMED = 1
+        AUTONOMOUS = 2
 
     def __init__(self):
         super().__init__("ueuos")
 
     def activate(self) -> None:
-        self.__client = self.supervisor.create_client(SetUeuosState, "ueuos/set_state")
+        self.__state_client = self.supervisor.create_client(SetUeuosState, "ueuos/set_state")
+        self.__color_client = self.supervisor.create_client(SetUeuosColor, "ueuos/set_color")
 
         # Set a dummy state to avoid None in get_state()
         # It will be instantly overwritten when entering the teleop state.
@@ -24,31 +31,73 @@ class Ueuos(Module):
         self.__wanted_state = Ueuos.State.OFF
         self.__req_future: Future = None
         self.__req_state: Ueuos.State | None = None
+        
+        # Track current color
+        self.__current_color: ColorRGBA | None = None
+        self.__wanted_color: ColorRGBA | None = None
+        self.__color_req_future: Future = None
+        self.__color_req: ColorRGBA | None = None
 
     def tick(self) -> None:
-        # If state change is needed and request is not pending, send the request.
+        # Handle standard state changes
         if self.__state != self.__wanted_state and self.__req_future is None:
             request = SetUeuosState.Request()
             request.state = self.__wanted_state
 
-            if not self.__client.service_is_ready():
+            if not self.__state_client.service_is_ready():
                 self.supervisor.get_logger().info("Waiting for ueuos/set_state...")
-                self.__client.wait_for_service()
+                self.__state_client.wait_for_service()
 
-            self.__req_future = self.__client.call_async(request)
+            self.__req_future = self.__state_client.call_async(request)
             self.__req_state = self.__wanted_state
 
-        # If a request is pending and it is done, update the state and clear request.
+        # If a state request is pending and it is done, update the state and clear request.
         if self.__req_future is not None and self.__req_future.done():
             self.__state = self.__req_state
             self.__req_future = None
             self.__req_state = None
+        
+        # Handle RSCP color state changes
+        if self.__wanted_color is not None and self.__color_req_future is None:
+            # Check if the wanted color is different from current
+            colors_differ = (
+                self.__current_color is None or
+                self.__current_color.r != self.__wanted_color.r or
+                self.__current_color.g != self.__wanted_color.g or
+                self.__current_color.b != self.__wanted_color.b
+            )
+            
+            if colors_differ:
+                request = SetUeuosColor.Request()
+                request.color = self.__wanted_color
+                
+                if not self.__color_client.service_is_ready():
+                    self.supervisor.get_logger().info("Waiting for ueuos/set_color...")
+                    self.__color_client.wait_for_service()
+
+                self.__color_req_future = self.__color_client.call_async(request)
+                self.__color_req = self.__wanted_color
+        
+        # If an RSCP color request is pending and it is done, update and clear
+        if self.__color_req_future is not None and self.__color_req_future.done():
+            self.__current_color = self.__color_req
+            self.__color_req_future = None
+            self.__color_req = None
 
     def deactivate(self) -> None:
-        self.supervisor.destroy_client(self.__client)
-
-    def get_state(self) -> State:
-        return self.__state
+        self.supervisor.destroy_client(self.__state_client)
+        self.supervisor.destroy_client(self.__color_client)
 
     def set_state(self, state: State) -> None:
+        """Set standard UEUOS state (OFF/AUTONOMY/TELEOP/FINISHED)."""
         self.__wanted_state = state
+    
+    def set_rscp_state(self, rscp_state: RscpState) -> None:
+        """Set RSCP-specific color state (DISARMED/ARMED/AUTONOMOUS)."""
+        # Map RSCP states to colors
+        if rscp_state == Ueuos.RscpState.DISARMED:
+            self.__wanted_color = ColorRGBA(r=1.0, g=0.0, b=0.0, a=1.0)
+        elif rscp_state == Ueuos.RscpState.ARMED:
+            self.__wanted_color = ColorRGBA(r=0.0, g=1.0, b=0.0, a=1.0)
+        elif rscp_state == Ueuos.RscpState.AUTONOMOUS:
+            self.__wanted_color = ColorRGBA(r=1.0, g=1.0, b=0.0, a=1.0)

--- a/kalman_supervisor/kalman_supervisor/states/__init__.py
+++ b/kalman_supervisor/kalman_supervisor/states/__init__.py
@@ -13,3 +13,6 @@ from kalman_supervisor.states.mapping_states.navigate import (
 )
 from kalman_supervisor.states.mapping_states.loop_closure import LoopClosure
 from kalman_supervisor.states.mapping_states.take_photos import TakePhotos
+
+from kalman_supervisor.states.rscp_states.rscp_idle import RscpIdle
+from kalman_supervisor.states.rscp_states.rscp_navigate_gps import RscpNavigateGps

--- a/kalman_supervisor/kalman_supervisor/states/rscp_states/rscp_idle.py
+++ b/kalman_supervisor/kalman_supervisor/states/rscp_states/rscp_idle.py
@@ -1,0 +1,55 @@
+from kalman_supervisor.state import State
+from kalman_supervisor.modules import *
+from kalman_interfaces.msg import ArcRscpRequest
+
+
+class RscpIdle(State):
+    def __init__(self):
+        super().__init__("rscp_idle")
+
+    def enter(self) -> None:
+        # Set UEUOS to show armed/disarmed state
+        if self.supervisor.rscp.is_armed():
+            self.supervisor.ueuos.set_rscp_state(Ueuos.RscpState.ARMED)
+        else:
+            self.supervisor.ueuos.set_rscp_state(Ueuos.RscpState.DISARMED)
+        
+        self.supervisor.get_logger().info("[RSCP] Entered idle state, waiting for requests...")
+
+    def tick(self) -> str | None:
+        # Check for pending requests (ARM_DISARM and SET_STAGE are handled by module)
+        if not self.supervisor.rscp.has_pending_request():
+            return None
+        
+        # Get the pending request
+        req = self.supervisor.rscp.pop_pending_request()
+        
+        if req.type == ArcRscpRequest.NAV_TO_GPS:
+            # Check if we're armed before allowing navigation
+            if not self.supervisor.rscp.is_armed():
+                self.supervisor.get_logger().warn(
+                    "[RSCP] NavigateToGPS rejected: rover is DISARMED"
+                )
+                # Could send a NACK here if we had such a message type
+                # For now, just stay in idle
+                return None
+            
+            # Handle NavigateToGPS request
+            # Store the goal in the module for the navigate state to use
+            self.supervisor.rscp.set_navigation_goal(req.latitude, req.longitude)
+            self.supervisor.rscp.send_ack()
+            self.supervisor.get_logger().info(
+                f"[RSCP] NavigateToGPS received (lat={req.latitude}, lon={req.longitude}), "
+                f"sent ACK, transitioning to rscp_navigate_gps"
+            )
+            # Transition to navigate state
+            return "rscp_navigate_gps"
+            
+        else:
+            self.supervisor.get_logger().warn(
+                f"[RSCP] Unknown request type {req.type}, ignoring"
+            )
+            return None
+
+    def exit(self) -> None:
+        pass

--- a/kalman_supervisor/kalman_supervisor/states/rscp_states/rscp_navigate_gps.py
+++ b/kalman_supervisor/kalman_supervisor/states/rscp_states/rscp_navigate_gps.py
@@ -1,0 +1,66 @@
+from kalman_supervisor.state import State
+from kalman_supervisor.modules import *
+
+
+class RscpNavigateGps(State):
+    def __init__(self):
+        super().__init__("rscp_navigate_gps")
+
+    def enter(self) -> None:
+        # Set UEUOS to autonomous (yellow)
+        self.supervisor.ueuos.set_rscp_state(Ueuos.RscpState.AUTONOMOUS)
+        
+        # Get the navigation goal from the RSCP module
+        goal = self.supervisor.rscp.get_navigation_goal()
+        
+        if goal is None:
+            self.supervisor.get_logger().error(
+                "[RSCP] No navigation goal set! Returning to rscp_idle"
+            )
+            self.failed = True
+            return
+        
+        lat, lon = goal
+        self.supervisor.get_logger().info(
+            f"[RSCP] Starting GPS navigation to ({lat}, {lon})"
+        )
+        
+        # Send the GPS goal to navigation
+        self.supervisor.nav.send_gps_goal(lat, lon)
+        self.failed = False
+
+    def tick(self) -> str | None:
+        # If we failed to set up navigation, return to idle
+        if self.failed:
+            return "rscp_idle"
+        
+        # Check if disarmed - abort and return to idle
+        if not self.supervisor.rscp.is_armed():
+            self.supervisor.get_logger().warn(
+                "[RSCP] DISARM detected during navigation, aborting"
+            )
+            # Navigation will be canceled in exit()
+            return "rscp_idle"
+        
+        # Check if navigation is complete
+        if not self.supervisor.nav.has_goal():
+            self.supervisor.get_logger().info(
+                "[RSCP] GPS navigation completed"
+            )
+            # Send TASK_FINISHED response
+            self.supervisor.rscp.send_task_finished()
+            # Clear the navigation goal
+            self.supervisor.rscp.clear_navigation_goal()
+            # Return to idle state to wait for next request
+            return "rscp_idle"
+        
+        # Still navigating
+        return None
+
+    def exit(self) -> None:
+        # Cancel navigation if we're exiting prematurely
+        if self.supervisor.nav.has_goal():
+            self.supervisor.get_logger().info(
+                "[RSCP] Exiting rscp_navigate_gps, canceling navigation"
+            )
+            self.supervisor.nav.cancel_goal()

--- a/kalman_supervisor/kalman_supervisor/supervisor_node.py
+++ b/kalman_supervisor/kalman_supervisor/supervisor_node.py
@@ -29,6 +29,7 @@ class Supervisor(Node):
         self.missions: Missions
         self.nav: Nav
         self.position_history: PositionHistory
+        self.rscp: Rscp
         self.tf: TF
         self.ueuos: Ueuos
 
@@ -91,7 +92,11 @@ class Supervisor(Node):
                 module.activate()
 
             # Enter initial state.
-            self.state = "teleop"
+            # If RSCP module is enabled, start in rscp_idle, otherwise teleop
+            if self.rscp.module_enabled:
+                self.state = "rscp_idle"
+            else:
+                self.state = "teleop"
             self.__state_dict[self.state].enter()
 
             # Start ticking.

--- a/kalman_supervisor/launch/supervisor.launch.py
+++ b/kalman_supervisor/launch/supervisor.launch.py
@@ -39,6 +39,9 @@ def launch_setup(context):
         for x in LaunchConfiguration("arch_camera_ids").perform(context).split(" ")
         if x != ""
     ]
+    rscp_enabled = (
+        LaunchConfiguration("rscp_enabled").perform(context).lower() == "true"
+    )
 
     remappings = []
 
@@ -62,11 +65,14 @@ def launch_setup(context):
         *remap_action("missions/mapping_goals", "supervisor/mapping_goals"),
         *remap_action("nav/navigate_to_pose", "navigate_to_pose"),
         ("ueuos/set_state", "ueuos/set_state"),
+        ("ueuos/set_color", "ueuos/set_color"),
         ("yolo/get_state", "yolo_detect/get_state"),
         ("yolo/change_state", "yolo_detect/change_state"),
         ("yolo/detections", "yolo_detections"),
         ("search/path_follower/set_parameters", "path_follower/set_parameters"),
         ("search/path_follower/get_parameters", "path_follower/get_parameters"),
+        ("rscp/req", "rscp/req"),
+        ("rscp/res", "rscp/res"),
     ]
 
     for i, camera_id in enumerate(arch_camera_ids):
@@ -94,6 +100,9 @@ def launch_setup(context):
                     },
                     "arch": {
                         "num_cameras": len(arch_camera_ids),
+                    },
+                    "rscp": {
+                        "enabled": rscp_enabled,
                     },
                 },
             ],
@@ -132,6 +141,12 @@ def generate_launch_description():
                 "arch_camera_ids",
                 default_value="",
                 description="Space-separated IDs of the cameras to take photos with during the ARCh 2025 mapping mission.",
+            ),
+            DeclareLaunchArgument(
+                "rscp_enabled",
+                default_value="false",
+                choices=["true", "false"],
+                description="Enable RSCP mode (start in rscp_idle instead of teleop).",
             ),
             OpaqueFunction(function=launch_setup),
         ]


### PR DESCRIPTION
- new `ArcRscpRequest.msg` and `ArcRscpResponse.msg` in kalman_interfaces supports RSCP frame types: ARM/DISARM, traverse to GPS coords

- adds a family of new launch files `kalman_bringup/launch/arc_..._.launch.py` to be used during ARC 2026

rscp protocol ref: https://github.com/anatolianroverchallenge/rscp